### PR TITLE
Ignore generated Makefile.old file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /Makefile
+/Makefile.old
 /pm_to_blib
 /*.bak
 /*.tmp


### PR DESCRIPTION
* Makefile.old file is generated by during `make clean` after building the Makefile with `perl Makefile.pl`
* `*.old` files are already ignored in the MANIFEST.