### PR TITLE
Remove example Cargo.lock file from MANIFEST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.bundle
 *.dylib
 /fbx.json
+examples/Person/ffi/Cargo.lock

--- a/MANIFEST
+++ b/MANIFEST
@@ -4,7 +4,6 @@ Changes
 CONTRIBUTING
 examples/add.pl
 examples/add.rs
-examples/Person/ffi/Cargo.lock
 examples/Person/ffi/Cargo.toml
 examples/Person/ffi/src/lib.rs
 examples/Person/lib/Person.pm


### PR DESCRIPTION
* Cargo.lock files are autogenerated by cargo
* ffi/Cargo.lock was committed as part of rebuild checks
  see git:d991eb17aef88e2123ba449b1483bec8b4d6b8e1
* Building in a clean check-out throws a warning because
  `examples/Person/ffi/Cargo.lock` isn't checked in

  ```
  % perl Makefile.pl && make

  Checking if your kit is complete...
  Warning: the following files are missing in your kit:
          examples/Person/ffi/Cargo.lock
  Please inform the author.
  ...
  ```